### PR TITLE
Added feature: variable start length when ramping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 .coverage
 dist
+*.pyc

--- a/brute.py
+++ b/brute.py
@@ -27,13 +27,15 @@ except ImportError:
     )
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 
-def brute(length=3, ramp=True, letters=True, numbers=True, symbols=True, spaces=False):
+def brute(start_length=1, length=3, ramp=True, letters=True, numbers=True, symbols=True, spaces=False):
     """
     Iterate through a sequence of possible strings, efficiently.
 
+    :param int start_length: The length of the string to begin ramping through.
+        This number must be less than length and greater than 0. Default: 1.
     :param int length: The length of the string to iterate through.  We'll
         iterate through all permutations of strings up to this length. Default:
         5.
@@ -56,12 +58,16 @@ def brute(length=3, ramp=True, letters=True, numbers=True, symbols=True, spaces=
     choices += _spaces if spaces else ''
     choices = ''.join(sample(choices, len(choices)))
 
+    if ramp:
+        if start_length < 1 or start_length > length:
+            start_length = 1
+
     return (
         ''.join(candidate) for candidate in
         chain.from_iterable(
             product(
                 choices,
                 repeat = i,
-            ) for i in range(1 if ramp else length, length + 1),
+            ) for i in range(start_length if ramp else length, length + 1),
         )
     )

--- a/test_brute.py
+++ b/test_brute.py
@@ -79,3 +79,7 @@ class TestBrute(TestCase):
     def test_ramp(self):
         for pw in brute(length=3, ramp=False):
             self.assertEqual(len(pw), 3)
+
+    def test_ramp_start_length(self):
+        for pw in brute(start_length=2, length=3, ramp=True):
+            self.assertTrue(len(pw) >= 2)

--- a/test_brute.py
+++ b/test_brute.py
@@ -83,3 +83,9 @@ class TestBrute(TestCase):
     def test_ramp_start_length(self):
         for pw in brute(start_length=2, length=3, ramp=True):
             self.assertTrue(len(pw) >= 2)
+
+    def test_ramp_bad_start_length(self):
+        for pw in brute(start_length=0, length=3, ramp=True):
+            self.assertTrue(len(pw) >= 1)
+        for pw in brute(start_length=4, length=3, ramp=True):
+            self.assertTrue(len(pw) < 4)


### PR DESCRIPTION
I wanted to add a variable start length to brute because I still want to be able to ramp in a program without having to rerun trivially small cases or having to write a wrapper around brute to mimic the same functionality. I added two test cases and reran the existing tests to make sure that I didn't break functionality with the existing library. In the case that a user uses an invalid start length, it reverts back to the original functionality of starting at a length of 1 for ramping.