### PR TITLE
Use xrange instead of range in Python 2

### DIFF
--- a/brute.py
+++ b/brute.py
@@ -8,6 +8,10 @@
 
 from itertools import chain, product
 from random import sample
+import sys
+
+if sys.version[0] == 2:
+    range = xrange
 
 # Python 2 and 3 have different string constants, so this makes the library
 # Python 3 compatible.

--- a/brute.py
+++ b/brute.py
@@ -10,7 +10,7 @@ from itertools import chain, product
 from random import sample
 import sys
 
-if sys.version[0] == 2:
+if sys.version[0] == "2":
     range = xrange
 
 # Python 2 and 3 have different string constants, so this makes the library


### PR DESCRIPTION
Using xrange instead of range in Python 2 is better for performance. I made a change that uses xrange if Python 2 is detected without breaking compatibility with Python 3.