### PR TITLE
Fix syntax error

### DIFF
--- a/brute.py
+++ b/brute.py
@@ -37,5 +37,5 @@ def brute(start_length=1, length=3, ramp=True, letters=True, numbers=True, symbo
 
     return (
         ''.join(candidate) for candidate in
-        chain.from_iterable(product(choices, repeat=i) for i in range(start_length if ramp else length, length+1))
+        chain.from_iterable((product(choices, repeat=i) for i in range(start_length if ramp else length, length+1)))
     )


### PR DESCRIPTION
### Fix
- Fix `SyntaxError: Generator expression must be parenthesized` ([#14](https://github.com/rdegges/brute/issues/14), [#12](https://github.com/rdegges/brute/issues/12), [#7](https://github.com/rdegges/brute/issues/7))

Added parenthesis around generator
